### PR TITLE
Support dumping/rendering a selection of regions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .DS_Store
 /**/.DS_Store
 .idea/
+.venv/
 /**/target/
 
 # Log file

--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ The files all assume your current working directory is the root of this reposito
 1. `cache.py` runs first (no arguments), downloading the latest live oldschool cache from https://archive.openrs2.org.
     - Cache files are stored in  in `./data/versions/{version_name}`
     - The auto-generated version name is used to (over)write `./data/versions/version.txt` containing just the version name.
-2. `MapExport.java` runs next (no arguments), reading the version name from the .txt. It generates:
-    - Imagery tiles (no labels or map icons) go in `./out/mapgen/versions/{version_name}/tiles/rendered`
+2. Edit `version.txt` if you only want to render certain regions. Leave version name on the first line, then subsequent lines contain the region id (e.g. 12850 for Lumbridge castle).
+3. `MapExport.java` runs next (no arguments), reading the version name from the .txt. It generates:
+    - Imagery tiles (no labels or map icons) go in `./out/mapgen/versions/{version_name}/tiles/base`
     - `minimapIcons.json` and `worldMapDefinitions.json` go in `./out/mapgen/versions/{version_name}`
-3. `stitch.py` runs last (no arguments), again reading the version name from the file, and rendering maps from the tiles in step 2.
+4. `stitch.py` runs last (no arguments), again reading the version name from the file, and rendering maps from the tiles in step 2.
     - Output images stored in `./out/mapgen/versions/{version_name}/output/tiles/rendered`
     - Output icons stored in `./out/mapgen/versions/{version_name}/output/icons`
     - Wiki basemap definitions go in `./out/mapgen/versions/{version_name}/output/basemaps.json`
-4. The directory `./out/mapgen/versions/{version_name}/output` can then be zipped and uploaded to map server.
+5. The directory `./out/mapgen/versions/{version_name}/output` can then be zipped and uploaded to map server.

--- a/osrs-wiki-maps/src/main/java/wiki/runescape/oldschool/maps/MapExport.java
+++ b/osrs-wiki-maps/src/main/java/wiki/runescape/oldschool/maps/MapExport.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Scanner;
-import java.util.logging.Level;
 
 public class MapExport {
     private static RegionLoader regionLoader;
@@ -38,6 +37,17 @@ public class MapExport {
         Scanner sc = new Scanner(versionTxt);
         version = sc.next();
         logger.info("Version: " + version);
+
+        List<Integer> regionDiffs = new ArrayList<>();
+        while (sc.hasNextLine()) {
+            String regionStr = sc.nextLine();
+            if (regionStr.isEmpty()) {
+                continue;
+            }
+            logger.info("Region: " + regionStr);
+            int regionInt = Integer.parseInt(regionStr);
+            regionDiffs.add(regionInt);
+        }
 
         String intermediateDir = String.format("./out/mapgen/versions/%s", version);
         outputDir = String.format("%s/output", intermediateDir);
@@ -64,6 +74,10 @@ public class MapExport {
         regionLoader = new RegionLoader(store, xteaKeyManager);
         regionLoader.loadRegions();
         for (Region region : regionLoader.getRegions()) {
+            int regionId = region.getRegionID();
+            if (!regionDiffs.isEmpty() && !regionDiffs.contains(regionId)) {
+                continue;
+            }
             int x = region.getRegionX();
             int y = region.getRegionY();
             String dirname = String.format("%s/tiles/base", intermediateDir);
@@ -102,7 +116,7 @@ public class MapExport {
     }
 
     private static List<WorldMapDefinition> getWorldMapDefinitions(Store store) throws Exception {
-        List<WorldMapDefinition> definitions = new ArrayList<WorldMapDefinition>();
+        List<WorldMapDefinition> definitions = new ArrayList<>();
         WorldMapLoader loader = new WorldMapLoader();
         Index index = store.getIndex(IndexType.WORLDMAP);
 
@@ -120,10 +134,10 @@ public class MapExport {
     }
 
     private static List<MinimapIcon> getMapIcons(Store store) throws Exception {
-        List<MinimapIcon> icons = new ArrayList<MinimapIcon>();
+        List<MinimapIcon> icons = new ArrayList<>();
         SpriteManager spriteManager = new SpriteManager(store);
         spriteManager.load();
-        HashSet<Integer> spriteIds = new HashSet<Integer>();
+        HashSet<Integer> spriteIds = new HashSet<>();
         ObjectManager objectManager = new ObjectManager(store);
         objectManager.load();
         AreaManager areaManager = new AreaManager(store);

--- a/osrs-wiki-maps/src/main/java/wiki/runescape/oldschool/maps/MapExport.java
+++ b/osrs-wiki-maps/src/main/java/wiki/runescape/oldschool/maps/MapExport.java
@@ -40,7 +40,7 @@ public class MapExport {
 
         List<Integer> regionDiffs = new ArrayList<>();
         while (sc.hasNextLine()) {
-            String regionStr = sc.nextLine();
+            String regionStr = sc.next();
             if (regionStr.isEmpty()) {
                 continue;
             }

--- a/osrs-wiki-maps/src/main/java/wiki/runescape/oldschool/maps/MapExport.java
+++ b/osrs-wiki-maps/src/main/java/wiki/runescape/oldschool/maps/MapExport.java
@@ -35,12 +35,12 @@ public class MapExport {
         String versionPath = "./data/versions/version.txt";
         File versionTxt = new File(versionPath);
         Scanner sc = new Scanner(versionTxt);
-        version = sc.next();
+        version = sc.nextLine();
         logger.info("Version: " + version);
 
         List<Integer> regionDiffs = new ArrayList<>();
         while (sc.hasNextLine()) {
-            String regionStr = sc.next();
+            String regionStr = sc.nextLine();
             if (regionStr.isEmpty()) {
                 continue;
             }


### PR DESCRIPTION
This lets us specify in version.txt if we want to dump/render any particular regions (e.g. only ones that have changed since previous cache). `stitch.py` still needs access to all of the base tiles whether those particular regions are selected or not, so it can render plane 0 without any stitch lines, and for the zoomed out images, of which a selected region might only be a tiny part.

Note that it doesn't *just* render the selected regions, but also all adjacent regions in case map icons have been altered that would cross the boundary of the selected regions into adjacent ones.